### PR TITLE
Fix 1.21.1 item compatibility crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,11 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.5.0</version>
                 <configuration>
@@ -116,6 +121,12 @@
             <artifactId>lombok</artifactId>
             <version>1.18.26</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <properties>

--- a/src/main/java/com/tining/demonmarket/common/util/PluginUtil.java
+++ b/src/main/java/com/tining/demonmarket/common/util/PluginUtil.java
@@ -33,6 +33,8 @@ import java.util.zip.GZIPOutputStream;
 
 public class PluginUtil {
 
+    private static final Map<String, String> NON_ITEM_MATERIAL_ALIASES = createNonItemMaterialAliases();
+
     /**
      * nms版本
      */
@@ -250,14 +252,67 @@ public class PluginUtil {
      * @return
      */
     public static ItemStack getItem(String name) {
-        if (Objects.isNull(name)) {
+        String materialName = normalizeMaterialName(name);
+        if (Objects.isNull(materialName)) {
             return null;
         }
-        Material material = Material.getMaterial(name);
-        if(Objects.isNull(material)){
+        Material material = resolveItemMaterial(materialName);
+        if (Objects.isNull(material) && !Objects.equals(materialName, name)) {
+            material = resolveItemMaterial(name);
+        }
+        if (Objects.isNull(material)) {
             return null;
         }
         return new ItemStack(material);
+    }
+
+    static String normalizeMaterialName(String name) {
+        if (Objects.isNull(name)) {
+            return null;
+        }
+
+        String normalized = name.trim();
+        if (normalized.isEmpty()) {
+            return null;
+        }
+
+        normalized = normalized.toUpperCase(Locale.ROOT);
+        return NON_ITEM_MATERIAL_ALIASES.getOrDefault(normalized, normalized);
+    }
+
+    private static Material resolveItemMaterial(String name) {
+        Material material = Material.matchMaterial(name);
+        if (isItem(material)) {
+            return material;
+        }
+
+        try {
+            material = Material.matchMaterial(name, true);
+        } catch (Throwable ignored) {
+            return null;
+        }
+
+        if (isItem(material)) {
+            return material;
+        }
+        return null;
+    }
+
+    private static boolean isItem(Material material) {
+        return !Objects.isNull(material) && material.isItem();
+    }
+
+    private static Map<String, String> createNonItemMaterialAliases() {
+        Map<String, String> aliases = new HashMap<>();
+        aliases.put("GRASS", "GRASS_BLOCK");
+        aliases.put("LAVA", "LAVA_BUCKET");
+        aliases.put("REDSTONEWIRE", "REDSTONE");
+        aliases.put("SOIL", "DIRT");
+        aliases.put("STATIONARYLAVA", "LAVA_BUCKET");
+        aliases.put("STATIONARYWATER", "WATER_BUCKET");
+        aliases.put("WALLSIGN", "OAK_SIGN");
+        aliases.put("WATER", "WATER_BUCKET");
+        return Collections.unmodifiableMap(aliases);
     }
 
     /**

--- a/src/test/java/com/tining/demonmarket/common/util/PluginUtilCompatibilityTest.java
+++ b/src/test/java/com/tining/demonmarket/common/util/PluginUtilCompatibilityTest.java
@@ -1,0 +1,29 @@
+package com.tining.demonmarket.common.util;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+
+public class PluginUtilCompatibilityTest {
+
+    @Test
+    public void mapsLegacyFluidNamesToDisplayItems() throws Exception {
+        assertEquals("WATER_BUCKET", normalizeMaterialName("WATER"));
+        assertEquals("WATER_BUCKET", normalizeMaterialName("STATIONARYWATER"));
+        assertEquals("LAVA_BUCKET", normalizeMaterialName("LAVA"));
+        assertEquals("LAVA_BUCKET", normalizeMaterialName("STATIONARYLAVA"));
+    }
+
+    @Test
+    public void leavesModernItemNamesUntouched() throws Exception {
+        assertEquals("DIAMOND", normalizeMaterialName("DIAMOND"));
+    }
+
+    private String normalizeMaterialName(String name) throws Exception {
+        Method method = PluginUtil.class.getDeclaredMethod("normalizeMaterialName", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, name);
+    }
+}


### PR DESCRIPTION
## Summary
- fix `PluginUtil.getItem()` so legacy names from `worth.yml` do not create non-item `Material`s on Paper 1.21.1
- map fluid and other non-item legacy names such as `WATER`, `STATIONARYWATER`, `LAVA`, and `STATIONARYLAVA` to safe display items before building `ItemStack`
- add a regression test for the legacy material normalization path and configure Surefire/JUnit for test execution

## Root Cause
Paper 1.21.1 rejects `new ItemStack(Material.WATER)` because `WATER` is no longer considered an item material. DemonMarket still loads historical worth entries using those names, so opening the acquire list could throw `IllegalArgumentException: WATER isn't an item`.

## Validation
- `mvn -q -Dtest=PluginUtilCompatibilityTest test` with JDK 17
- `mvn -q -DskipTests package` with JDK 17
